### PR TITLE
Use reproject for image registration 

### DIFF
--- a/aiapy/calibrate/meta.py
+++ b/aiapy/calibrate/meta.py
@@ -12,6 +12,7 @@ from astropy.coordinates import CartesianRepresentation, HeliocentricMeanEclipti
 from sunpy.map import contains_full_disk
 
 from aiapy.calibrate.util import get_pointing_table
+from aiapy.util import detector_dimensions
 from aiapy.util.exceptions import AiapyUserWarning
 
 __all__ = ['fix_observer_location', 'update_pointing']
@@ -93,7 +94,7 @@ def update_pointing(smap, pointing_table=None):
     # This function can only be applied to full-resolution, full-frame images
     if not contains_full_disk(smap):
         raise ValueError("Input must be a full disk image.")
-    shape_full_frame = (4096, 4096)
+    shape_full_frame = detector_dimensions().value
     if not all(d == (s*u.pixel) for d, s in zip(smap.dimensions, shape_full_frame)):
         raise ValueError(f"Input must be at the full resolution of {shape_full_frame}")
     if pointing_table is None:

--- a/aiapy/calibrate/spikes.py
+++ b/aiapy/calibrate/spikes.py
@@ -10,7 +10,7 @@ from astropy.wcs.utils import pixel_to_pixel
 from sunpy.map.mapbase import PixelPair
 from sunpy.map.sources.sdo import AIAMap
 
-from aiapy.util import AiapyUserWarning
+from aiapy.util import AiapyUserWarning, detector_dimensions
 
 __all__ = ['respike', 'fetch_spikes']
 
@@ -141,7 +141,7 @@ def fetch_spikes(smap, as_coords=False):
     )
     _, spikes = fits.open(f'http://jsoc.stanford.edu{file["spikes"][0]}')
     spikes = spikes.data
-    shape_full_frame = (4096, 4096)
+    shape_full_frame = detector_dimensions().value
     values = spikes[1, :]
     y_coords, x_coords = np.unravel_index(spikes[0, :], shape=shape_full_frame)
     # If this is a cutout, need to transform the full-frame pixel

--- a/aiapy/psf/psf.py
+++ b/aiapy/psf/psf.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import astropy.units as u
 
+from aiapy.util import detector_dimensions
 from aiapy.util.decorators import validate_channel
 
 try:
@@ -274,7 +275,7 @@ def psf(channel: u.angstrom, use_preflightcore=False, diffraction_orders=None, u
 
 
 def _psf(meshinfo, angles, diffraction_orders, focal_plane=False, use_gpu=True):
-    psf = np.zeros((4096, 4096), dtype=float)
+    psf = np.zeros(detector_dimensions().value, dtype=float)
     # If cupy is available, cast to a cupy array
     if HAS_CUPY and use_gpu:
         psf = cupy.array(psf)

--- a/aiapy/util/util.py
+++ b/aiapy/util/util.py
@@ -11,7 +11,7 @@ from sunpy.time import parse_time
 
 from aiapy.util.decorators import validate_channel
 
-__all__ = ['sdo_location', 'telescope_number']
+__all__ = ['sdo_location', 'telescope_number', 'detector_dimensions']
 
 
 def sdo_location(time):
@@ -77,3 +77,11 @@ def telescope_number(channel: u.angstrom):
         1700*u.angstrom: 3,
         4500*u.angstrom: 3,
     }[channel]
+
+
+@u.quantity_input
+def detector_dimensions():
+    """
+    Dimensions of the detector in row-major order.
+    """
+    return u.Quantity((4096, 4096), 'pixel', dtype=int)


### PR DESCRIPTION
Fixes #125 

This is a first pass at using the `reproject` package to perform image registration by constructing a WCS for the aligned, translated, and scaled image and reprojecting the input map into that new WCS. This also now works for submaps. Note that this does not add a dependency as `reproject` is an optional dependency of sunpy that we already pick up by requiring `sunpy[map]`.

I've marked this as a draft because it still needs quite a bit of cleaning up and I'd like several pairs of eyes on it before we even think about merging (if we do at all).

There is also the issue of performance. This is markedly slower for full-disk images by an OOM. 

```python
In [22]: %%timeit
    ...: m_l15_cutout = aiapy.calibrate.prep.register_reproject(m_l1_cutout)
1.6 s ± 15.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [23]: %%timeit
    ...: m_l15 = aiapy.calibrate.prep.register_reproject(m_l1)
33.5 s ± 749 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [24]: %%timeit
    ...: m_l15 = aiapy.calibrate.prep.register(m_l1)
WARNING: SunpyUserWarning: Integer input data has been cast to float64. [sunpy.image.transform]
3.34 s ± 10.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

However, this version does have the advantage that prep on submaps is possible. Additionally, `reproject` offers several different algorithms for performing the actual reprojection and [there are proposed performance improvements.](). There is also progress being made on [parallelizing the `map_coordinates` function with Dask](https://github.com/dask/dask-image/pull/237) which is the underlying scipy function called by `reproject_interp`. There's also a [cupy version of `map_coordinates`](https://docs.cupy.dev/en/stable/reference/generated/cupyx.scipy.ndimage.map_coordinates.html).

All my comments above are assuming that the performance bottleneck is the `map_coordinates` function, i.e. the actual interpolation of the array onto the new coordinates. While this is almost certainly true, it should be confirmed with some profiling.

Some TODOs:

- [ ] Fix up docstring
- [ ] Fix tests--need a submap test and to remove/modify some of our existing tests.
- [ ] Changelog
- [ ] Quantitative comparisons with our current version of `register`
- [ ] Comparisons to aiaprep in SSW?
- [ ] Performance...