### PR TITLE
Catch Erfa warnings

### DIFF
--- a/changelog/324.trivial.rst
+++ b/changelog/324.trivial.rst
@@ -1,0 +1,1 @@
+Catch all `erfa.core.ErfaWarning` that are raised when we convert the times from the error and degradation tables into UTC while making them `astropy.time.Time` objects.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ filterwarnings = [
   "ignore:numpy.ufunc size changed:RuntimeWarning",
   "ignore:numpy.ndarray size changed:RuntimeWarning",
   "ignore:.*unitfix.*",
-  "ignore::erfa.core.ErfaWarning",
   "ignore:invalid value encountered in sqrt",
 ]
 


### PR DESCRIPTION
Fixes #89 

This PR catches the Erfa warnings that are raised when we convert the times from the error and degradation tables into UTC while making them `astropy.time.Time` objects.