### PR TITLE
Account for use of reference_date property

### DIFF
--- a/aiapy/calibrate/meta.py
+++ b/aiapy/calibrate/meta.py
@@ -123,16 +123,10 @@ def update_pointing(smap, *, pointing_table=None):
     # NOTE: For SDO data, T_OBS is preferred to DATE-OBS in the case of the
     # MPT, using DATE-OBS from near the slot boundary might result in selecting
     # an incorrect MPT record.
+    # FIXME: Beginning in sunpy v6.0.0, AIA maps use T_OBS as the reference date
+    # As such, once that is the min version supported, the following lines should
+    # be adjusted to just use smap.reference_date
     t_obs = smap.meta.get("T_OBS")
-    if t_obs is None:
-        warnings.warn(
-            "T_OBS key is missing from metadata. Falling back to Map.date. "
-            "This may result in selecting in incorrect record from the "
-            "master pointing table.",
-            AiapyUserWarning,
-            stacklevel=3,
-        )
-        t_obs = smap.date
     t_obs = astropy.time.Time(t_obs)
     t_obs_in_interval = np.logical_and(t_obs >= pointing_table["T_START"], t_obs < pointing_table["T_STOP"])
     if not t_obs_in_interval.any():

--- a/aiapy/calibrate/meta.py
+++ b/aiapy/calibrate/meta.py
@@ -48,7 +48,12 @@ def fix_observer_location(smap):
         z=smap.meta["haez_obs"] * u.m,
         representation_type=CartesianRepresentation,
         frame=HeliocentricMeanEcliptic,
-        obstime=smap.reference_date,
+        # FIXME: Beginning in sunpy v6.0.0, the reference_date property
+        # was added as the date to be used to property instantiate the
+        # coordinate frame. As such, this should be used if possible.
+        # Once the minimum version of sunpy is 6.0.0 or above, this should
+        # just be set to reference_date.
+        obstime=getattr(smap, "reference_date", None) or smap.date,
     ).heliographic_stonyhurst
     # Update header
     new_meta = copy.deepcopy(smap.meta)
@@ -126,7 +131,7 @@ def update_pointing(smap, *, pointing_table=None):
     # FIXME: Beginning in sunpy v6.0.0, AIA maps use T_OBS as the reference date
     # As such, once that is the min version supported, the following lines should
     # be adjusted to just use smap.reference_date
-    t_obs = smap.meta.get("T_OBS")
+    t_obs = getattr(smap, "reference_date", None) or smap.meta.get("T_OBS") or smap.date
     t_obs = astropy.time.Time(t_obs)
     t_obs_in_interval = np.logical_and(t_obs >= pointing_table["T_START"], t_obs < pointing_table["T_STOP"])
     if not t_obs_in_interval.any():

--- a/aiapy/calibrate/meta.py
+++ b/aiapy/calibrate/meta.py
@@ -48,7 +48,7 @@ def fix_observer_location(smap):
         z=smap.meta["haez_obs"] * u.m,
         representation_type=CartesianRepresentation,
         frame=HeliocentricMeanEcliptic,
-        obstime=smap.date,
+        obstime=smap.reference_date,
     ).heliographic_stonyhurst
     # Update header
     new_meta = copy.deepcopy(smap.meta)

--- a/aiapy/calibrate/spikes.py
+++ b/aiapy/calibrate/spikes.py
@@ -79,7 +79,7 @@ def respike(smap, *, spikes=None):
         warnings.warn(
             (
                 f"{smap.scale} is significantly different from the expected level "
-                "1 plate scale {nominal_scale}. If this map has been interpolated "
+                f"1 plate scale {nominal_scale}. If this map has been interpolated "
                 "in any way from the level 1 image, the spike data will likely be "
                 "reinserted in the incorrect pixel positions."
             ),

--- a/aiapy/calibrate/tests/test_meta.py
+++ b/aiapy/calibrate/tests/test_meta.py
@@ -86,15 +86,6 @@ def test_update_pointing_accuracy(aia_171_map, pointing_table, t_delt_factor, ex
     assert aia_map_updated.reference_pixel.y == pointing_table[expected_entry]["A_171_Y0"]
 
 
-@pytest.mark.skip()  # Because sunpy pulls reference_date from T_OBS, this test will always fail. Maybe remove?
-@pytest.mark.remote_data()
-def test_update_pointing_missing_tobs_raises_warning(aia_171_map, pointing_table):
-    # Tests that a warning is raised if T_OBS is not present.
-    aia_171_map.meta.pop("T_OBS")
-    with pytest.warns(AiapyUserWarning, match="T_OBS key is missing from metadata."):
-        update_pointing(aia_171_map, pointing_table=pointing_table)
-
-
 @pytest.mark.remote_data()
 def test_update_pointing_submap_raises_exception(aia_171_map, pointing_table):
     m = aia_171_map.submap(

--- a/aiapy/calibrate/tests/test_meta.py
+++ b/aiapy/calibrate/tests/test_meta.py
@@ -13,9 +13,9 @@ from aiapy.util.exceptions import AiapyUserWarning
 def test_fix_observer_location(aia_171_map):
     smap_fixed = fix_observer_location(aia_171_map)
     # NOTE: AIAMap already fixes the .observer_coordinate property with HAE
-    assert smap_fixed.meta["hgln_obs"] == smap_fixed.observer_coordinate.lon.value
-    assert smap_fixed.meta["hglt_obs"] == smap_fixed.observer_coordinate.lat.value
-    assert smap_fixed.meta["dsun_obs"] == smap_fixed.observer_coordinate.radius.value
+    assert u.allclose(smap_fixed.meta["hgln_obs"], smap_fixed.observer_coordinate.lon.value, atol=None, rtol=1e-6)
+    assert u.allclose(smap_fixed.meta["hglt_obs"], smap_fixed.observer_coordinate.lat.value, atol=None, rtol=1e-6)
+    assert u.allclose(smap_fixed.meta["dsun_obs"], smap_fixed.observer_coordinate.radius.value, atol=None, rtol=1e-6)
 
 
 @pytest.fixture()
@@ -86,6 +86,7 @@ def test_update_pointing_accuracy(aia_171_map, pointing_table, t_delt_factor, ex
     assert aia_map_updated.reference_pixel.y == pointing_table[expected_entry]["A_171_Y0"]
 
 
+@pytest.mark.skip()  # Because sunpy pulls reference_date from T_OBS, this test will always fail. Maybe remove?
 @pytest.mark.remote_data()
 def test_update_pointing_missing_tobs_raises_warning(aia_171_map, pointing_table):
     # Tests that a warning is raised if T_OBS is not present.

--- a/aiapy/calibrate/tests/test_meta.py
+++ b/aiapy/calibrate/tests/test_meta.py
@@ -13,9 +13,9 @@ from aiapy.util.exceptions import AiapyUserWarning
 def test_fix_observer_location(aia_171_map):
     smap_fixed = fix_observer_location(aia_171_map)
     # NOTE: AIAMap already fixes the .observer_coordinate property with HAE
-    assert u.allclose(smap_fixed.meta["hgln_obs"], smap_fixed.observer_coordinate.lon.value, atol=None, rtol=1e-6)
-    assert u.allclose(smap_fixed.meta["hglt_obs"], smap_fixed.observer_coordinate.lat.value, atol=None, rtol=1e-6)
-    assert u.allclose(smap_fixed.meta["dsun_obs"], smap_fixed.observer_coordinate.radius.value, atol=None, rtol=1e-6)
+    assert smap_fixed.meta["hgln_obs"] == smap_fixed.observer_coordinate.lon.value
+    assert smap_fixed.meta["hglt_obs"] == smap_fixed.observer_coordinate.lat.value
+    assert smap_fixed.meta["dsun_obs"] == smap_fixed.observer_coordinate.radius.value
 
 
 @pytest.fixture()

--- a/changelog/345.bugfix.rst
+++ b/changelog/345.bugfix.rst
@@ -1,0 +1,2 @@
+Use `~sunpy.map.GenericMap.reference_date` when constructing an observer coordinate and in place
+of pulling ``T_OBS`` directly from the header.


### PR DESCRIPTION
This PR includes a few fixes to account for the existence of the new `reference_date`property on `Map` which is the correct date to use when constructing the coordinate frame and observer coordinate. 

This also now assumes the existence of the "T_OBS" key in the metadata since this is what is used for constructing `reference_date` in the case of an AIA map. 

Since `reference_date` was only introduced in sunpy v6 we should decide how to go about using this property or just make the minimum version of sunpy v6.

See also sunpy/sunpy#7810

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the code to use the 'reference_date' property for constructing coordinate frames and observer coordinates, assuming the presence of 'T_OBS' in metadata for AIA maps. Adjust tests to reflect these changes and improve accuracy.

Bug Fixes:
- Fix the use of the incorrect date for constructing the coordinate frame and observer coordinate by using the new 'reference_date' property instead of 'smap.date'.

Enhancements:
- Assume the existence of the 'T_OBS' key in the metadata for constructing 'reference_date' in AIA maps, aligning with changes in sunpy v6.

Tests:
- Update tests to use 'u.allclose' for asserting observer coordinate values with a relative tolerance, improving test accuracy.
- Remove the test that checks for a warning when 'T_OBS' is missing from metadata, as this scenario is no longer applicable.

<!-- Generated by sourcery-ai[bot]: end summary -->