### PR TITLE
Updates from the package template

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/sunpy/package-template",
-  "commit": "4f11e366c6efc9dcb5658ca952ec4196e201212b",
+  "commit": "7bda107a752e07008add69c658519487eeb15bcb",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -32,7 +32,7 @@
         ".github/workflows/sub_package_update.yml"
       ],
       "_template": "https://github.com/sunpy/package-template",
-      "_commit": "4f11e366c6efc9dcb5658ca952ec4196e201212b"
+      "_commit": "7bda107a752e07008add69c658519487eeb15bcb"
     }
   },
   "directory": null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,9 @@ jobs:
       toxdeps: tox-pypi-filter
       envs: |
         - windows: py311
-<<<<<<<
-        - macos: py310-oldestdeps
-=======
         - macos: py312
         - linux: py310-oldestdeps
         - linux: py313-devdeps
->>>>>>>
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -111,26 +107,6 @@ jobs:
               - graphviz
         - linux: py312-online
 
-<<<<<<<
-  cron:
-    if: |
-      github.event_name == 'workflow_dispatch' || (
-        github.event_name == 'pull_request' &&
-        contains(github.event.pull_request.labels.*.name, 'Run cron CI')
-      )
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
-    with:
-      default_python: '3.12'
-      submodules: false
-      coverage: codecov
-      toxdeps: tox-pypi-filter
-      envs: |
-        - linux: py313-devdeps
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-=======
->>>>>>>
   publish:
     # Build wheels on PRs only when labelled. Releases will only be published if tagged ^v.*
     # see https://github-actions-workflows.openastronomy.org/en/latest/publish.html#upload-to-pypi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ on:
   pull_request:
   # Allow manual runs through the web UI
   workflow_dispatch:
+  schedule:
+    #        ┌───────── minute (0 - 59)
+    #        │ ┌───────── hour (0 - 23)
+    #        │ │ ┌───────── day of the month (1 - 31)
+    #        │ │ │ ┌───────── month (1 - 12 or JAN-DEC)
+    #        │ │ │ │ ┌───────── day of the week (0 - 6 or SUN-SAT)
+    - cron: '0 7 * * 3'  # Every Wed at 07:00 UTC
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,13 +29,13 @@ concurrency:
 
 jobs:
   core:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       submodules: false
       coverage: codecov
       toxdeps: tox-pypi-filter
       envs: |
-        - linux: py312
+        - linux: py313
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -46,20 +53,26 @@ jobs:
 
   test:
     needs: [core, sdist_verify]
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       submodules: false
       coverage: codecov
       toxdeps: tox-pypi-filter
       envs: |
         - windows: py311
+<<<<<<<
         - macos: py310-oldestdeps
+=======
+        - macos: py312
+        - linux: py310-oldestdeps
+        - linux: py313-devdeps
+>>>>>>>
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   docs:
     needs: [core]
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v2
     with:
       default_python: '3.12'
       submodules: false
@@ -98,6 +111,7 @@ jobs:
               - graphviz
         - linux: py312-online
 
+<<<<<<<
   cron:
     if: |
       github.event_name == 'workflow_dispatch' || (
@@ -115,6 +129,8 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+=======
+>>>>>>>
   publish:
     # Build wheels on PRs only when labelled. Releases will only be published if tagged ^v.*
     # see https://github-actions-workflows.openastronomy.org/en/latest/publish.html#upload-to-pypi
@@ -125,7 +141,7 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'Run publish')
       )
     needs: [test, docs]
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v2
     with:
       python-version: '3.12'
       test_extras: 'all,tests'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,7 @@ repos:
         args: ["--in-place", "--pre-summary-newline", "--make-summary-multi"]
     # This should be before any formatting hooks like isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-<<<<<<<
-    rev: "v0.11.4"
-=======
     rev: "v0.11.12"
->>>>>>>
     hooks:
       - id: ruff
         args: ["--fix", "--unsafe-fixes"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,11 @@ repos:
         args: ["--in-place", "--pre-summary-newline", "--make-summary-multi"]
     # This should be before any formatting hooks like isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
+<<<<<<<
     rev: "v0.11.4"
+=======
+    rev: "v0.11.12"
+>>>>>>>
     hooks:
       - id: ruff
         args: ["--fix", "--unsafe-fixes"]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,9 @@ build:
       - git fetch --unshallow || true
     pre_install:
       - git update-index --assume-unchanged .rtd-environment.yml docs/conf.py
+    post_install:
+    # Pin numpy for now
+     - pip install -U "numpy<2.3.0"
 
 conda:
   environment: .rtd-environment.yml

--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -2,6 +2,6 @@ name: rtd_aiapy
 channels:
   - conda-forge
 dependencies:
-  - python=3.12
+  - python=3.13
   - pip
   - graphviz!=2.42.*,!=2.43.*

--- a/aiapy/data/_sample.py
+++ b/aiapy/data/_sample.py
@@ -78,7 +78,7 @@ def _handle_final_errors(results) -> None:
 
 def _get_sampledata_dir():
     # Workaround for tox only. This is not supported as a user option
-    sampledata_dir = os.environ.get("SUNPY_SAMPLEDIR", False)
+    sampledata_dir = os.environ.get("SUNPY_SAMPLEDIR")
     if sampledata_dir:
         sampledata_dir = Path(sampledata_dir).expanduser().resolve()
         _is_writable_dir(sampledata_dir)

--- a/aiapy/data/sample.py
+++ b/aiapy/data/sample.py
@@ -29,7 +29,7 @@ from ._sample import _SAMPLE_DATA, _get_sample_files
 
 # Add a table row to the module docstring for each sample file
 for _keyname, _filename in sorted(_SAMPLE_DATA.items()):
-    __doc__ += f"   * - ``{_keyname}``\n     - {_filename}\n"  # NOQA: A001
+    __doc__ += f"   * - ``{_keyname}``\n     - {_filename}\n"
 
 
 # file_dict and file_list are not normal variables; see __getattr__() below

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,9 @@ warnings.filterwarnings("error", category=SunpyPendingDeprecationWarning)
 warnings.filterwarnings("error", category=MatplotlibDeprecationWarning)
 warnings.filterwarnings("error", category=AstropyDeprecationWarning)
 
+# Wrap large function/method signatures
+maximum_signature_line_length = 80
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named "sphinx.ext.*") or your custom
 # ones.

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,8 @@ set_env =
     MPLBACKEND = agg
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 deps =
+    # Pin due to parsing long times in astropy with this version of numpy
+    numpy<2.3.0
     cupy: cupy-cuda12x
     # For packages which publish nightly wheels this will pull the latest nightly
     devdeps: astropy>=0.0.dev0


### PR DESCRIPTION
This is an autogenerated PR, which will applies the latest changes from the [SunPy Package Template](https://github.com/sunpy/package-template).
If this pull request has been opened as a draft there are conflicts which need fixing.

**To run the CI on this pull request you will need to close it and reopen it.**

## Summary by Sourcery

Integrate the latest SunPy package template updates by refreshing CI workflows to v2, adding a weekly scheduled run, updating Python versions in test matrices, tightening documentation config, and bumping pre-commit tooling.

CI:
- Add a weekly scheduled CI run (cron every Wednesday at 07:00 UTC)
- Upgrade core, test, docs, and publish workflows to v2
- Update CI matrix Python versions: bump Linux to py313, macOS to py312, and add Linux py310-oldestdeps and py313-devdeps
- Remove the legacy cron CI job

Documentation:
- Set maximum Sphinx function/method signature line length to 80

Chores:
- Bump ruff version in pre-commit config to v0.11.12
- Refresh package template metadata in .cruft.json