### PR TITLE
Modify `update_pointing` to allow for submaps

### DIFF
--- a/aiapy/calibrate/meta.py
+++ b/aiapy/calibrate/meta.py
@@ -29,9 +29,10 @@ def update_pointing(smap, *, pointing_table):
 
     .. warning::
 
-        This function is only intended to be used for full-disk images
-        at the full resolution of 4096x4096 pixels. It will raise a
-        ``ValueError`` if the input map does not meet these criteria.
+        This function is only intended to be used on level 1 images,
+        including cutouts/submaps. This function should be applied before
+        rotating, resampling, rebinning, or interpolating the map in any
+        way.
 
     Parameters
     ----------

--- a/aiapy/calibrate/meta.py
+++ b/aiapy/calibrate/meta.py
@@ -9,8 +9,6 @@ import numpy as np
 
 import astropy.units as u
 
-from sunpy.map import contains_full_disk
-
 from aiapy.util.exceptions import AIApyUserWarning
 
 __all__ = ["update_pointing"]
@@ -52,13 +50,18 @@ def update_pointing(smap, *, pointing_table):
     --------
     `aiapy.calibrate.util.get_pointing_table`
     """
-    if not contains_full_disk(smap):
-        msg = "Input must be a full disk image."
-        raise ValueError(msg)
-    shape_full_frame = (4096, 4096)
-    if not all(d == (s * u.pixel) for d, s in zip(smap.dimensions, shape_full_frame, strict=True)):
-        msg = f"Input must be at the full resolution of {shape_full_frame}"
-        raise ValueError(msg)
+    # NOTE: Warn user if it looks like they may have changed the resolution of their map
+    # as this will cause the pointing update to be incorrect. This is not a strict check
+    # because the exact plate scale is not known a priori.
+    target_plate_scale = 0.6 * u.arcsec / u.pixel
+    if not all(np.fabs(u.Quantity(smap.scale) / target_plate_scale - 1) < 0.01):
+        msg = (
+            f"Input map has plate scale {u.Quantity(smap.scale)} which is significantly "
+            f"different than {target_plate_scale}. This function is only meant to be used "
+            "with maps which have not been resampled or rebinned. The updated pointing is "
+            "likely incorrect."
+        )
+        warnings.warn(msg, AIApyUserWarning, stacklevel=3)
     # Find row in which T_START <= T_OBS < T_STOP
     # The following notes are from a private communication with J. Serafin (LMSAL)
     # and are preserved here to explain the reasoning for selecting the particular
@@ -90,10 +93,20 @@ def update_pointing(smap, *, pointing_table):
     # of the Sun in CCD pixel coordinates (0-based), but FITS WCS indexing is
     # 1-based. See Section 2.2 of
     # http://jsoc.stanford.edu/~jsoc/keywords/AIA/AIA02840_K_AIA-SDO_FITS_Keyword_Document.pdf
-    x0_mp = pointing_table[f"A_{w_str}_X0"][i_nearest].to_value("pix")
-    y0_mp = pointing_table[f"A_{w_str}_Y0"][i_nearest].to_value("pix")
-    crpix1 = x0_mp + 1
-    crpix2 = y0_mp + 1
+    x0_mp_new = pointing_table[f"A_{w_str}_X0"][i_nearest].to_value("pix")
+    y0_mp_new = pointing_table[f"A_{w_str}_Y0"][i_nearest].to_value("pix")
+    crpix1 = smap.reference_pixel.x.to_value("pix") + 1
+    crpix2 = smap.reference_pixel.y.to_value("pix") + 1
+    # NOTE: Updating the reference pixel in this way only works if the map has not been
+    # rotated or resampled from the original level 1 data. It is calculated in this way
+    # to allow for updating the pointing in cropped maps.
+    if (x0_mp_old := smap.meta.get("x0_mp")) and (y0_mp_old := smap.meta.get("y0_mp")):
+        crpix1 += x0_mp_new - x0_mp_old
+        crpix2 += y0_mp_new - y0_mp_old
+    else:
+        warnings.warn(
+            "x0_mp and/or y0_mp keywords are missing. Skipping reference pixel update.", AIApyUserWarning, stacklevel=3
+        )
     cdelt = pointing_table[f"A_{w_str}_IMSCALE"][i_nearest].to_value("arcsecond / pixel")
     # CROTA2 is the sum of INSTROT and SAT_ROT.
     # See http://jsoc.stanford.edu/~jsoc/keywords/AIA/AIA02840_H_AIA-SDO_FITS_Keyword_Document.pdf
@@ -104,11 +117,11 @@ def update_pointing(smap, *, pointing_table):
     for key, value in [
         ("crpix1", crpix1),
         ("crpix2", crpix2),
-        ("x0_mp", x0_mp),  # x0_mp and y0_mp are not standard FITS keywords but they are
-        ("y0_mp", y0_mp),  # used when respiking submaps so we update them here.
         ("cdelt1", cdelt),
         ("cdelt2", cdelt),
         ("crota2", crota2),
+        ("x0_mp", x0_mp_new),  # x0_mp and y0_mp are not standard FITS keywords but they are
+        ("y0_mp", y0_mp_new),  # used when respiking submaps so they are updated here.
     ]:
         if np.isnan(value):
             # There are some entries in the pointing table returned from the JSOC that are marked as

--- a/aiapy/calibrate/meta.py
+++ b/aiapy/calibrate/meta.py
@@ -101,7 +101,7 @@ def update_pointing(smap, *, pointing_table):
     # NOTE: Updating the reference pixel in this way only works if the map has not been
     # rotated or resampled from the original level 1 data. It is calculated in this way
     # to allow for updating the pointing in cropped maps.
-    if (x0_mp_old := smap.meta.get("x0_mp")) and (y0_mp_old := smap.meta.get("y0_mp")):
+    if ((x0_mp_old := smap.meta.get("x0_mp")) is not None) and ((y0_mp_old := smap.meta.get("y0_mp")) is not None):
         crpix1 += x0_mp_new - x0_mp_old
         crpix2 += y0_mp_new - y0_mp_old
     else:

--- a/aiapy/calibrate/tests/test_meta.py
+++ b/aiapy/calibrate/tests/test_meta.py
@@ -31,25 +31,25 @@ def mock_pointing_table():
         names=(
             "T_START",
             "T_STOP",
-            "A_171_X0",
-            "A_171_Y0",
-            "A_171_INSTROT",
-            "A_171_IMSCALE",
+            "A_193_X0",
+            "A_193_Y0",
+            "A_193_INSTROT",
+            "A_193_IMSCALE",
         ),
     )
 
 
 @pytest.mark.remote_data
-def test_fix_pointing(aia_171_map, pointing_table) -> None:
+def test_fix_pointing(aia_193_level1_map, pointing_table) -> None:
     # Smoke test to make sure expected keys are being updated
     keys = ["crpix1", "crpix2", "cdelt1", "cdelt2", "crota2", "x0_mp", "y0_mp"]
     # NOTE: This modification forces CROTA2 and CDELT{1,2} to be updated. Otherwise,
     # these keys are not modified since the existing metadata and the pointing table
     # for this time are the same.
     new_pointing_table = pointing_table.copy()
-    new_pointing_table["A_171_INSTROT"] = 0 * u.deg
-    new_pointing_table["A_171_IMSCALE"] = 1.2 * u.arcsec / u.pixel
-    aia_map_updated = update_pointing(aia_171_map, pointing_table=new_pointing_table)
+    new_pointing_table["A_193_INSTROT"] = 0 * u.deg
+    new_pointing_table["A_193_IMSCALE"] = 1.2 * u.arcsec / u.pixel
+    aia_map_updated = update_pointing(aia_193_level1_map, pointing_table=new_pointing_table)
     for k in keys:
         assert k in aia_map_updated.meta.modified_items
 
@@ -70,25 +70,29 @@ def test_fix_pointing(aia_171_map, pointing_table) -> None:
         (1.001, 1),
     ],
 )
-def test_update_pointing_accuracy(aia_171_map, pointing_table, t_delt_factor, expected_entry) -> None:
+def test_update_pointing_accuracy(aia_193_level1_map, pointing_table, t_delt_factor, expected_entry) -> None:
     t_start = pointing_table[0]["T_START"]
     t_delt = pointing_table[0]["T_STOP"] - t_start  # This is nearly always 3 hours
-    aia_171_map.meta["T_OBS"] = (t_start + t_delt * t_delt_factor).isot
-    aia_map_updated = update_pointing(aia_171_map, pointing_table=pointing_table)
-    assert aia_map_updated.reference_pixel.x == pointing_table[expected_entry]["A_171_X0"]
-    assert aia_map_updated.reference_pixel.y == pointing_table[expected_entry]["A_171_Y0"]
+    aia_193_level1_map.meta["T_OBS"] = (t_start + t_delt * t_delt_factor).isot
+    aia_map_updated = update_pointing(aia_193_level1_map, pointing_table=pointing_table)
+    assert aia_map_updated.reference_pixel.x == pointing_table[expected_entry]["A_193_X0"]
+    assert aia_map_updated.reference_pixel.y == pointing_table[expected_entry]["A_193_Y0"]
 
 
 @pytest.mark.remote_data
-def test_update_pointing_submap(aia_171_map, pointing_table) -> None:
+def test_update_pointing_submap(aia_193_level1_map, pointing_table) -> None:
     # Tests that submapping and update pointing are commutative
     # NOTE: Purposefully cropping in pixel space as cropping in world space
     # can lead to differences of 1 pixel due to the differing world-to-pixel
     # conversions because of the change in reference pixel.
     blc = (500, 1000) * u.pixel
     trc = (1000, 1200) * u.pixel
-    m_submap_pointing_update = update_pointing(aia_171_map.submap(blc, top_right=trc), pointing_table=pointing_table)
-    m_pointing_update_submap = update_pointing(aia_171_map, pointing_table=pointing_table).submap(blc, top_right=trc)
+    m_submap_pointing_update = update_pointing(
+        aia_193_level1_map.submap(blc, top_right=trc), pointing_table=pointing_table
+    )
+    m_pointing_update_submap = update_pointing(aia_193_level1_map, pointing_table=pointing_table).submap(
+        blc, top_right=trc
+    )
     assert u.allclose(
         u.Quantity(m_submap_pointing_update.reference_pixel),
         u.Quantity(m_pointing_update_submap.reference_pixel),
@@ -97,36 +101,36 @@ def test_update_pointing_submap(aia_171_map, pointing_table) -> None:
 
 
 @pytest.mark.remote_data
-def test_update_pointing_resampled_warning(aia_171_map, pointing_table) -> None:
-    m = aia_171_map.resample((512, 512) * u.pixel)
+def test_update_pointing_resampled_warning(aia_193_level1_map, pointing_table) -> None:
+    m = aia_193_level1_map.resample((512, 512) * u.pixel)
     with pytest.warns(AIApyUserWarning, match="Input map has plate scale"):
         update_pointing(m, pointing_table=pointing_table)
 
 
 @pytest.mark.remote_data
-def test_update_pointing_missing_mp_keys(aia_171_map, pointing_table) -> None:
-    new_meta = copy.deepcopy(aia_171_map.meta)
+def test_update_pointing_missing_mp_keys(aia_193_level1_map, pointing_table) -> None:
+    new_meta = copy.deepcopy(aia_193_level1_map.meta)
     del new_meta["x0_mp"]
-    m = aia_171_map._new_instance(aia_171_map.data, new_meta)
+    m = aia_193_level1_map._new_instance(aia_193_level1_map.data, new_meta)
     with pytest.warns(AIApyUserWarning, match="x0_mp and/or y0_mp keywords are missing."):
         update_pointing(m, pointing_table=pointing_table)
 
 
 @pytest.mark.remote_data
-def test_update_pointing_no_entry_raises_exception(aia_171_map, pointing_table) -> None:
+def test_update_pointing_no_entry_raises_exception(aia_193_level1_map, pointing_table) -> None:
     # This tests that an exception is thrown when entry corresponding to
     # T_START <= T_OBS < T_END cannot be found in the pointing table.
     # We explicitly set the T_OBS key
-    aia_171_map.meta["T_OBS"] = (aia_171_map.date - 30 * u.year).isot
+    aia_193_level1_map.meta["T_OBS"] = (aia_193_level1_map.date - 30 * u.year).isot
     with pytest.raises(IndexError, match="No valid entries for"):
-        update_pointing(aia_171_map, pointing_table=pointing_table)
+        update_pointing(aia_193_level1_map, pointing_table=pointing_table)
 
 
-def test_fix_pointing_missing_value(aia_171_map, mock_pointing_table) -> None:
+def test_fix_pointing_missing_value(aia_193_level1_map, mock_pointing_table) -> None:
     # Adjust map to a date we know has missing pointing information
-    aia_171_map.meta["date-obs"] = "2010-09-30T06:51:48.344"
-    aia_171_map.meta["t_obs"] = aia_171_map.meta["date-obs"]
+    aia_193_level1_map.meta["date-obs"] = "2010-09-30T06:51:48.344"
+    aia_193_level1_map.meta["t_obs"] = aia_193_level1_map.meta["date-obs"]
     with pytest.warns(AIApyUserWarning, match="Missing value in pointing table"):
-        aia_171_map_updated = update_pointing(aia_171_map, pointing_table=mock_pointing_table)
-    assert aia_171_map.meta["crpix1"] == aia_171_map_updated.meta["crpix1"]
-    assert aia_171_map.meta["crpix2"] == aia_171_map_updated.meta["crpix2"]
+        aia_171_map_updated = update_pointing(aia_193_level1_map, pointing_table=mock_pointing_table)
+    assert aia_193_level1_map.meta["crpix1"] == aia_171_map_updated.meta["crpix1"]
+    assert aia_193_level1_map.meta["crpix2"] == aia_171_map_updated.meta["crpix2"]

--- a/aiapy/calibrate/tests/test_meta.py
+++ b/aiapy/calibrate/tests/test_meta.py
@@ -113,7 +113,9 @@ def test_update_pointing_missing_mp_keys(aia_193_level1_map, pointing_table) -> 
     del new_meta["x0_mp"]
     m = aia_193_level1_map._new_instance(aia_193_level1_map.data, new_meta)
     with pytest.warns(AIApyUserWarning, match="x0_mp and/or y0_mp keywords are missing."):
-        update_pointing(m, pointing_table=pointing_table)
+        m_updated = update_pointing(m, pointing_table=pointing_table)
+    assert m.reference_pixel.x == m_updated.reference_pixel.x
+    assert m.reference_pixel.y == m_updated.reference_pixel.y
 
 
 @pytest.mark.remote_data

--- a/aiapy/calibrate/tests/test_spikes.py
+++ b/aiapy/calibrate/tests/test_spikes.py
@@ -14,21 +14,13 @@ from aiapy.util import AIApyUserWarning
 
 
 @pytest.fixture
-def despiked_map():
-    # Need an actual 4K-by-4K map to do the spike replacement
-    return sunpy.map.Map(
-        "https://github.com/sunpy/data/blob/main/aiapy/aia_lev1_193a_2013_03_15t12_01_06_84z_image_lev1.fits?raw=true",
-    )
+def respiked_map(aia_193_level1_map):
+    return respike(aia_193_level1_map)
 
 
 @pytest.fixture
-def respiked_map(despiked_map):
-    return respike(despiked_map)
-
-
-@pytest.fixture
-def spikes(despiked_map):
-    return fetch_spikes(despiked_map)
+def spikes(aia_193_level1_map):
+    return fetch_spikes(aia_193_level1_map)
 
 
 @pytest.mark.remote_data
@@ -45,13 +37,13 @@ def test_respike_meta(respiked_map) -> None:
 
 
 @pytest.mark.remote_data
-def test_fetch_with_prefetched_spikes(despiked_map, respiked_map, spikes) -> None:
-    respiked_map_prefetched = respike(despiked_map, spikes=spikes)
+def test_fetch_with_prefetched_spikes(aia_193_level1_map, respiked_map, spikes) -> None:
+    respiked_map_prefetched = respike(aia_193_level1_map, spikes=spikes)
     assert np.allclose(respiked_map.data, respiked_map_prefetched.data)
 
 
 @pytest.mark.remote_data
-def test_cutout(respiked_map, despiked_map) -> None:
+def test_cutout(respiked_map, aia_193_level1_map) -> None:
     blc = (-500, -500) * u.arcsec
     trc = (500, 500) * u.arcsec
     respiked_map_cutout = respiked_map.submap(
@@ -59,9 +51,9 @@ def test_cutout(respiked_map, despiked_map) -> None:
         top_right=SkyCoord(*trc, frame=respiked_map.coordinate_frame),
     )
     cutout_map_respiked = respike(
-        despiked_map.submap(
-            SkyCoord(*blc, frame=despiked_map.coordinate_frame),
-            top_right=SkyCoord(*trc, frame=despiked_map.coordinate_frame),
+        aia_193_level1_map.submap(
+            SkyCoord(*blc, frame=aia_193_level1_map.coordinate_frame),
+            top_right=SkyCoord(*trc, frame=aia_193_level1_map.coordinate_frame),
         ),
     )
     assert np.allclose(respiked_map_cutout.data, cutout_map_respiked.data)
@@ -76,16 +68,16 @@ def test_cutout(respiked_map, despiked_map) -> None:
         ("instrume", "not AIA", TypeError, "Input must be an AIAMap."),
     ],
 )
-def test_exceptions(despiked_map, key, value, error, match) -> None:
-    new_meta = copy.deepcopy(despiked_map.meta)
+def test_exceptions(aia_193_level1_map, key, value, error, match) -> None:
+    new_meta = copy.deepcopy(aia_193_level1_map.meta)
     new_meta[key] = value
     with pytest.raises(error, match=match):
-        respike(sunpy.map.Map(despiked_map.data, new_meta))
+        respike(sunpy.map.Map(aia_193_level1_map.data, new_meta))
 
 
 @pytest.mark.remote_data
-def test_resample_warning(despiked_map) -> None:
-    despiked_map_resample = despiked_map.resample((512, 512) * u.pixel)
+def test_resample_warning(aia_193_level1_map) -> None:
+    despiked_map_resample = aia_193_level1_map.resample((512, 512) * u.pixel)
     with (
         pytest.warns(AIApyUserWarning, match="is significantly different from the expected level 1 plate scale"),
         pytest.warns(ResourceWarning),
@@ -95,9 +87,9 @@ def test_resample_warning(despiked_map) -> None:
 
 @pytest.mark.remote_data
 @pytest.mark.parametrize(("as_coords", "kind"), [(True, SkyCoord), (False, PixelPair)])
-def test_fetch_spikes(despiked_map, as_coords, kind) -> None:
-    n_spikes = despiked_map.meta["nspikes"]
-    coords, values = fetch_spikes(despiked_map, as_coords=as_coords)
+def test_fetch_spikes(aia_193_level1_map, as_coords, kind) -> None:
+    n_spikes = aia_193_level1_map.meta["nspikes"]
+    coords, values = fetch_spikes(aia_193_level1_map, as_coords=as_coords)
     assert isinstance(coords, kind)
     assert values.size == n_spikes
     if as_coords:

--- a/aiapy/conftest.py
+++ b/aiapy/conftest.py
@@ -28,6 +28,14 @@ def aia_171_map():
 
 
 @pytest.fixture
+def aia_193_level1_map():
+    # Need an actual 4K-by-4K map to do the spike replacement
+    return sunpy.map.Map(
+        "https://github.com/sunpy/data/blob/main/aiapy/aia_lev1_193a_2013_03_15t12_01_06_84z_image_lev1.fits?raw=true",
+    )
+
+
+@pytest.fixture
 def psf_94(channels):
     import aiapy.psf  # NOQA: PLC0415
 

--- a/changelog/362.feature.rst
+++ b/changelog/362.feature.rst
@@ -1,0 +1,4 @@
+Modify :func:`~aiapy.calibrate.update_pointing` to allow for updating pointing information
+of maps that have been cropped. This function no longer raises an exception if the input map
+does not include the full Sun or is not at the expected resolution. A warning is now raised
+if the plate scale is significantly different (:math:`>1\%`) than the expected plate scale.


### PR DESCRIPTION
This PR modifies the `aiapy.calibrate.meta.update_pointing` function to account for maps which have been submapped (but not rotated, resampled, or rebinned). The logic here is modify the reference pixel by the difference between the AIA pointing keywords "X0_MP" and "Y0_MP". These are non-standard FITS keys so they are not modified when submapping and thus preserve the original pointing of the full-disk map. 

## TODO

- [x] Fix test failure. For some reason, the pointing accuracy test for full-disk maps is failing.
- [x] Add changelog
- [x] Fix docstring

## Summary by Sourcery

Enable update_pointing to work on cutouts/submaps by offsetting reference pixels based on preserved full-disk pointing keywords and warn users when the plate scale indicates resampling, while refactoring tests to validate the new behavior

New Features:
- Allow update_pointing to support submaps by adjusting the reference pixel using differences in x0_mp and y0_mp

Enhancements:
- Replace strict full-disk resolution checks with a configurable plate-scale warning
- Retain and update non-standard x0_mp and y0_mp FITS keywords when submapping

Documentation:
- Update docstring and add changelog entry

Tests:
- Refactor pointing tests to use 193Å level 1 maps
- Add tests for submap commutativity, resample warnings, missing metadata keys, and no-entry exception