### PR TITLE
Random

### DIFF
--- a/aiapy/calibrate/meta.py
+++ b/aiapy/calibrate/meta.py
@@ -113,7 +113,7 @@ def update_pointing(smap, *, pointing_table):
     # See http://jsoc.stanford.edu/~jsoc/keywords/AIA/AIA02840_H_AIA-SDO_FITS_Keyword_Document.pdf
     # NOTE: Is the value of SAT_ROT in the header accurate?
     crota2 = pointing_table[f"A_{w_str}_INSTROT"][i_nearest] + smap.meta["SAT_ROT"] * u.degree
-    crota2 = crota2.to_value("deg")
+    crota2 = crota2.to_value("degree")
     # Update headers
     for key, value in [
         ("crpix1", crpix1),

--- a/aiapy/calibrate/tests/test_meta.py
+++ b/aiapy/calibrate/tests/test_meta.py
@@ -47,7 +47,7 @@ def test_fix_pointing(aia_193_level1_map, pointing_table) -> None:
     # these keys are not modified since the existing metadata and the pointing table
     # for this time are the same.
     new_pointing_table = pointing_table.copy()
-    new_pointing_table["A_193_INSTROT"] = 0 * u.deg
+    new_pointing_table["A_193_INSTROT"] = 0 * u.degree
     new_pointing_table["A_193_IMSCALE"] = 1.2 * u.arcsec / u.pixel
     aia_map_updated = update_pointing(aia_193_level1_map, pointing_table=new_pointing_table)
     for k in keys:

--- a/aiapy/calibrate/tests/test_prep.py
+++ b/aiapy/calibrate/tests/test_prep.py
@@ -124,7 +124,7 @@ def test_correct_degradation(aia_171_map, source) -> None:
         uncorrected_over_corrected = aia_171_map.data / original_corrected.data
     # If intensity is zero, ratio will be NaN/infinite
     i_valid = aia_171_map.data > 0.0
-    assert np.allclose(uncorrected_over_corrected[i_valid], d)
+    np.testing.assert_allclose(np.mean(uncorrected_over_corrected[i_valid]), d.to_value())
 
 
 @pytest.mark.parametrize(
@@ -254,4 +254,4 @@ def test_register_cupy(aia_171_map) -> None:
     pytest.importorskip("cupy")
     cupy_map = register(aia_171_map, method="cupy")
     scipy_map = register(aia_171_map, method="scipy")
-    assert np.allclose(cupy_map.data, scipy_map.data)
+    np.testing.assert_allclose(cupy_map.data, scipy_map.data)

--- a/aiapy/calibrate/tests/test_spikes.py
+++ b/aiapy/calibrate/tests/test_spikes.py
@@ -39,7 +39,7 @@ def test_respike_meta(respiked_map) -> None:
 @pytest.mark.remote_data
 def test_fetch_with_prefetched_spikes(aia_193_level1_map, respiked_map, spikes) -> None:
     respiked_map_prefetched = respike(aia_193_level1_map, spikes=spikes)
-    assert np.allclose(respiked_map.data, respiked_map_prefetched.data)
+    np.testing.assert_allclose(respiked_map.data, respiked_map_prefetched.data)
 
 
 @pytest.mark.remote_data
@@ -56,7 +56,7 @@ def test_cutout(respiked_map, aia_193_level1_map) -> None:
             top_right=SkyCoord(*trc, frame=aia_193_level1_map.coordinate_frame),
         ),
     )
-    assert np.allclose(respiked_map_cutout.data, cutout_map_respiked.data)
+    np.testing.assert_allclose(respiked_map_cutout.data, cutout_map_respiked.data)
 
 
 @pytest.mark.remote_data

--- a/aiapy/psf/__init__.py
+++ b/aiapy/psf/__init__.py
@@ -5,3 +5,4 @@ point spread function (PSF).
 
 from .deconvolve import *
 from .psf import *
+from .utils import *

--- a/aiapy/psf/psf.py
+++ b/aiapy/psf/psf.py
@@ -9,6 +9,7 @@ import astropy.units as u
 from sunpy import log
 from sunpy.util.decorators import deprecated
 
+from aiapy.psf.utils import filter_mesh_parameters
 from aiapy.utils.decorators import validate_channel
 
 try:
@@ -18,159 +19,7 @@ try:
 except ImportError:
     HAS_CUPY = False
 
-__all__ = ["_psf", "calculate_psf", "filter_mesh_parameters", "psf"]
-
-
-def filter_mesh_parameters(*, use_preflightcore=False):
-    """
-    Geometric parameters for meshes in AIA filters used to calculate the point
-    spread function.
-
-    Parameters
-    ----------
-    use_preflightcore : `bool`, optional
-        If True, use the pre-flight values for the filter mesh parameters
-
-    Returns
-    -------
-    meshinfo : `dict`
-        Dictionary with filter mesh information for each channel. Each channel
-        entry then contains another dictionary with the following keys
-        describing filter mesh properties of that channel
-        (see Table 2 of [1]_):
-
-        * ``angle_arm``: Angles of the four entrance filter arms
-        * ``error_angle_arm``: Error in angle of the four entrance filter arms
-        * ``spacing_e``: Distance between diffraction spikes from entrance filter
-        * ``spacing_fp``: Distance between diffraction spikes from focal plane filter
-        * ``mesh_pitch``: Pitch of the mesh
-        * ``mesh_width``: Width of the mesh
-        * ``width``: Width applied to the Gaussian such that *after*
-          convolution we have the proper width
-          (:math:`4/3` at :math:`1/e` of max)
-
-    References
-    ----------
-    .. [1] `Grigis, P., Su, Y., Weber M., et al., 2012,
-            AIA PSF Characterization and Deconvolution
-            <https://sohoftp.nascom.nasa.gov/solarsoft/sdo/aia/idl/psf/DOC/psfreport.pdf>`_
-
-    See Also
-    --------
-    `calculate_psf` : Calculate the composite point spread function
-
-    Notes
-    -----
-    These parameters were calculated from the following images and
-    reference background images.
-
-    94:
-
-    * image: 'AIA20101016_191039_0094.fits'
-    * reference: 'AIA20101016_190903_0094.fits'
-
-    131:
-
-    * image: 'AIA20101016_191035_0131.fits'
-    * reference: 'AIA20101016_190911_0131.fits'
-
-    171:
-
-    * image: 'AIA20101016_191037_0171.fits'
-    * reference: 'AIA20101016_190901_0171.fits'
-
-    193:
-
-    * image: 'AIA20101016_191056_0193.fits'
-    * reference: 'AIA20101016_190844_0193.fits'
-
-    211:
-
-    * image: 'AIA20101016_191038_0211.fits'
-    * reference: 'AIA20101016_190902_0211.fits'
-
-    304:
-
-    * image: 'AIA20101016_191021_0304.fits'
-    * reference: 'AIA20101016_190845_0304.fits'
-
-    335:
-
-    * image: 'AIA20101016_191041_0335.fits'
-    * reference: 'AIA20101016_190905_0335.fits'
-    """
-    return {
-        94 * u.angstrom: {
-            "angle_arm": [49.81, 40.16, -40.28, -49.92] * u.deg,
-            "error_angle_arm": [0.02, 0.02, 0.02, 0.02] * u.deg,
-            "spacing_e": 8.99 * u.pixel,
-            "mesh_pitch": 363.0 * u.um,
-            "mesh_width": 34.0 * u.um,
-            "spacing_fp": 0.207 * u.pixel,
-            "width": (0.951 if use_preflightcore else 4.5) * u.pixel,
-            "CDELT": [0.600109, 0.600109] * u.arcsec,
-        },
-        131 * u.angstrom: {
-            "angle_arm": [50.27, 40.17, -39.70, -49.95] * u.deg,
-            "error_angle_arm": [0.02, 0.02, 0.02, 0.02] * u.deg,
-            "spacing_e": 12.37 * u.pixel,
-            "mesh_pitch": 363.0 * u.um,
-            "mesh_width": 34.0 * u.um,
-            "spacing_fp": 0.289 * u.pixel,
-            "width": (1.033 if use_preflightcore else 4.5) * u.pixel,
-            "CDELT": [0.600698, 0.600698] * u.arcsec,
-        },
-        171 * u.angstrom: {
-            "angle_arm": [49.81, 39.57, -40.13, -50.38] * u.deg,
-            "error_angle_arm": [0.02, 0.02, 0.02, 0.02] * u.deg,
-            "spacing_e": 16.26 * u.pixel,
-            "mesh_pitch": 363.0 * u.um,
-            "mesh_width": 34.0 * u.um,
-            "spacing_fp": 0.377 * u.pixel,
-            "width": (0.962 if use_preflightcore else 4.5) * u.pixel,
-            "CDELT": [0.599489, 0.599489] * u.arcsec,
-        },
-        193 * u.angstrom: {
-            "angle_arm": [49.82, 39.57, -40.12, -50.37] * u.deg,
-            "error_angle_arm": [0.02, 0.02, 0.03, 0.04] * u.deg,
-            "spacing_e": 18.39 * u.pixel,
-            "mesh_pitch": 363.0 * u.um,
-            "mesh_width": 34.0 * u.um,
-            "spacing_fp": 0.425 * u.pixel,
-            "width": (1.512 if use_preflightcore else 4.5) * u.pixel,
-            "CDELT": [0.600758, 0.600758] * u.arcsec,
-        },
-        211 * u.angstrom: {
-            "angle_arm": [49.78, 40.08, -40.34, -49.95] * u.deg,
-            "error_angle_arm": [0.02, 0.02, 0.02, 0.02] * u.deg,
-            "spacing_e": 19.97 * u.pixel,
-            "mesh_pitch": 363.0 * u.um,
-            "mesh_width": 34.0 * u.um,
-            "spacing_fp": 0.465 * u.pixel,
-            "width": (1.199 if use_preflightcore else 4.5) * u.pixel,
-            "CDELT": [0.600758, 0.600758] * u.arcsec,
-        },
-        304 * u.angstrom: {
-            "angle_arm": [49.76, 40.18, -40.14, -49.90] * u.degree,
-            "error_angle_arm": [0.02, 0.02, 0.02, 0.02] * u.deg,
-            "spacing_e": 28.87 * u.pixel,
-            "mesh_pitch": 363.0 * u.um,
-            "mesh_width": 34.0 * u.um,
-            "spacing_fp": 0.670 * u.pixel,
-            "width": (1.247 if use_preflightcore else 4.5) * u.pixel,
-            "CDELT": [0.600165, 0.600165] * u.arcsec,
-        },
-        335 * u.angstrom: {
-            "angle_arm": [50.40, 39.80, -39.64, -50.25] * u.degree,
-            "error_angle_arm": [0.02, 0.02, 0.02, 0.02] * u.deg,
-            "spacing_e": 31.83 * u.pixel,
-            "mesh_pitch": 363.0 * u.um,
-            "mesh_width": 34.0 * u.um,
-            "spacing_fp": 0.738 * u.pixel,
-            "width": (0.962 if use_preflightcore else 4.5) * u.pixel,
-            "CDELT": [0.600737, 0.600737] * u.arcsec,
-        },
-    }
+__all__ = ["calculate_psf", "psf"]
 
 
 @u.quantity_input
@@ -335,7 +184,7 @@ def _psf(meshinfo, angles, diffraction_orders, *, focal_plane=False, use_gpu=Tru
     return (1 - area_not_mesh) * psf / psf.sum() + area_not_mesh * psf_core / psf_core.sum()
 
 
-@deprecated("1.0", alternative="calculate_psf")
+@deprecated("0.11.0", alternative="calculate_psf")
 @u.quantity_input
 def psf(channel: u.angstrom, *, use_preflightcore=False, diffraction_orders=None, use_gpu=True):
     """

--- a/aiapy/psf/tests/test_psf.py
+++ b/aiapy/psf/tests/test_psf.py
@@ -1,26 +1,4 @@
 import numpy as np
-import pytest
-
-import aiapy.psf
-from aiapy.conftest import CHANNELS
-
-MESH_PROPERTIES = [
-    "angle_arm",
-    "error_angle_arm",
-    "spacing_e",
-    "spacing_fp",
-    "mesh_pitch",
-    "mesh_width",
-    "width",
-]
-
-
-@pytest.mark.parametrize("use_preflightcore", [True, False])
-def test_filter_mesh_parameters(use_preflightcore) -> None:
-    params = aiapy.psf.filter_mesh_parameters(use_preflightcore=use_preflightcore)
-    assert isinstance(params, dict)
-    assert all(c in params for c in CHANNELS)
-    assert all(all(p in params[c] for p in MESH_PROPERTIES) for c in CHANNELS)
 
 
 def test_psf(psf) -> None:

--- a/aiapy/psf/tests/test_utils.py
+++ b/aiapy/psf/tests/test_utils.py
@@ -1,0 +1,22 @@
+import pytest
+
+import aiapy.psf
+from aiapy.conftest import CHANNELS
+
+MESH_PROPERTIES = [
+    "angle_arm",
+    "error_angle_arm",
+    "spacing_e",
+    "spacing_fp",
+    "mesh_pitch",
+    "mesh_width",
+    "width",
+]
+
+
+@pytest.mark.parametrize("use_preflightcore", [True, False])
+def test_filter_mesh_parameters(use_preflightcore) -> None:
+    params = aiapy.psf.filter_mesh_parameters(use_preflightcore=use_preflightcore)
+    assert isinstance(params, dict)
+    assert all(c in params for c in CHANNELS)
+    assert all(all(p in params[c] for p in MESH_PROPERTIES) for c in CHANNELS)

--- a/aiapy/psf/utils.py
+++ b/aiapy/psf/utils.py
@@ -1,0 +1,159 @@
+"""
+Contains utility functions for the AIA PSF calculations.
+"""
+
+import astropy.units as u
+
+__all__ = ["filter_mesh_parameters"]
+
+
+def filter_mesh_parameters(*, use_preflightcore=False):
+    """
+    Geometric parameters for meshes in AIA filters used to calculate the point
+    spread function.
+
+    Parameters
+    ----------
+    use_preflightcore : `bool`, optional
+        If True, use the pre-flight values for the filter mesh parameters
+
+    Returns
+    -------
+    meshinfo : `dict`
+        Dictionary with filter mesh information for each channel. Each channel
+        entry then contains another dictionary with the following keys
+        describing filter mesh properties of that channel
+        (see Table 2 of [1]_):
+
+        * ``angle_arm``: Angles of the four entrance filter arms
+        * ``error_angle_arm``: Error in angle of the four entrance filter arms
+        * ``spacing_e``: Distance between diffraction spikes from entrance filter
+        * ``spacing_fp``: Distance between diffraction spikes from focal plane filter
+        * ``mesh_pitch``: Pitch of the mesh
+        * ``mesh_width``: Width of the mesh
+        * ``width``: Width applied to the Gaussian such that *after*
+          convolution we have the proper width
+          (:math:`4/3` at :math:`1/e` of max)
+
+    References
+    ----------
+    .. [1] `Grigis, P., Su, Y., Weber M., et al., 2012,
+            AIA PSF Characterization and Deconvolution
+            <https://sohoftp.nascom.nasa.gov/solarsoft/sdo/aia/idl/psf/DOC/psfreport.pdf>`_
+
+    See Also
+    --------
+    `calculate_psf` : Calculate the composite point spread function
+
+    Notes
+    -----
+    These parameters were calculated from the following images and
+    reference background images.
+
+    94:
+
+    * image: 'AIA20101016_191039_0094.fits'
+    * reference: 'AIA20101016_190903_0094.fits'
+
+    131:
+
+    * image: 'AIA20101016_191035_0131.fits'
+    * reference: 'AIA20101016_190911_0131.fits'
+
+    171:
+
+    * image: 'AIA20101016_191037_0171.fits'
+    * reference: 'AIA20101016_190901_0171.fits'
+
+    193:
+
+    * image: 'AIA20101016_191056_0193.fits'
+    * reference: 'AIA20101016_190844_0193.fits'
+
+    211:
+
+    * image: 'AIA20101016_191038_0211.fits'
+    * reference: 'AIA20101016_190902_0211.fits'
+
+    304:
+
+    * image: 'AIA20101016_191021_0304.fits'
+    * reference: 'AIA20101016_190845_0304.fits'
+
+    335:
+
+    * image: 'AIA20101016_191041_0335.fits'
+    * reference: 'AIA20101016_190905_0335.fits'
+    """
+    return {
+        94 * u.angstrom: {
+            "angle_arm": [49.81, 40.16, -40.28, -49.92] * u.degree,
+            "error_angle_arm": [0.02, 0.02, 0.02, 0.02] * u.degree,
+            "spacing_e": 8.99 * u.pixel,
+            "mesh_pitch": 363.0 * u.um,
+            "mesh_width": 34.0 * u.um,
+            "spacing_fp": 0.207 * u.pixel,
+            "width": (0.951 if use_preflightcore else 4.5) * u.pixel,
+            "CDELT": [0.600109, 0.600109] * u.arcsec,
+        },
+        131 * u.angstrom: {
+            "angle_arm": [50.27, 40.17, -39.70, -49.95] * u.degree,
+            "error_angle_arm": [0.02, 0.02, 0.02, 0.02] * u.degree,
+            "spacing_e": 12.37 * u.pixel,
+            "mesh_pitch": 363.0 * u.um,
+            "mesh_width": 34.0 * u.um,
+            "spacing_fp": 0.289 * u.pixel,
+            "width": (1.033 if use_preflightcore else 4.5) * u.pixel,
+            "CDELT": [0.600698, 0.600698] * u.arcsec,
+        },
+        171 * u.angstrom: {
+            "angle_arm": [49.81, 39.57, -40.13, -50.38] * u.degree,
+            "error_angle_arm": [0.02, 0.02, 0.02, 0.02] * u.degree,
+            "spacing_e": 16.26 * u.pixel,
+            "mesh_pitch": 363.0 * u.um,
+            "mesh_width": 34.0 * u.um,
+            "spacing_fp": 0.377 * u.pixel,
+            "width": (0.962 if use_preflightcore else 4.5) * u.pixel,
+            "CDELT": [0.599489, 0.599489] * u.arcsec,
+        },
+        193 * u.angstrom: {
+            "angle_arm": [49.82, 39.57, -40.12, -50.37] * u.degree,
+            "error_angle_arm": [0.02, 0.02, 0.03, 0.04] * u.degree,
+            "spacing_e": 18.39 * u.pixel,
+            "mesh_pitch": 363.0 * u.um,
+            "mesh_width": 34.0 * u.um,
+            "spacing_fp": 0.425 * u.pixel,
+            "width": (1.512 if use_preflightcore else 4.5) * u.pixel,
+            "CDELT": [0.600758, 0.600758] * u.arcsec,
+        },
+        211 * u.angstrom: {
+            "angle_arm": [49.78, 40.08, -40.34, -49.95] * u.degree,
+            "error_angle_arm": [0.02, 0.02, 0.02, 0.02] * u.degree,
+            "spacing_e": 19.97 * u.pixel,
+            "mesh_pitch": 363.0 * u.um,
+            "mesh_width": 34.0 * u.um,
+            "spacing_fp": 0.465 * u.pixel,
+            "width": (1.199 if use_preflightcore else 4.5) * u.pixel,
+            "CDELT": [0.600758, 0.600758] * u.arcsec,
+        },
+        304 * u.angstrom: {
+            "angle_arm": [49.76, 40.18, -40.14, -49.90] * u.degree,
+            "error_angle_arm": [0.02, 0.02, 0.02, 0.02] * u.degree,
+            "spacing_e": 28.87 * u.pixel,
+            "mesh_pitch": 363.0 * u.um,
+            "mesh_width": 34.0 * u.um,
+            "spacing_fp": 0.670 * u.pixel,
+            "width": (1.247 if use_preflightcore else 4.5) * u.pixel,
+            "CDELT": [0.600165, 0.600165] * u.arcsec,
+        },
+        335 * u.angstrom: {
+            "angle_arm": [50.40, 39.80, -39.64, -50.25] * u.degree,
+            "error_angle_arm": [0.02, 0.02, 0.02, 0.02] * u.degree,
+            "spacing_e": 31.83 * u.pixel,
+            "mesh_pitch": 363.0 * u.um,
+            "mesh_width": 34.0 * u.um,
+            "spacing_fp": 0.738 * u.pixel,
+            "width": (0.962 if use_preflightcore else 4.5) * u.pixel,
+            "CDELT": [0.600737, 0.600737] * u.arcsec,
+        },
+    }

--- a/aiapy/tests/test_idl.py
+++ b/aiapy/tests/test_idl.py
@@ -89,4 +89,4 @@ def test_psf_consistent(psf_94, psf_idl) -> None:
     # NOTE: Only compare values above some threshold as the
     # rest of the PSF is essentially noise
     i_valid = np.where(psf_idl > 1e-10)
-    assert np.allclose(psf_94[i_valid], psf_idl[i_valid])
+    np.testing.assert_allclose(psf_94[i_valid], psf_idl[i_valid], rtol=2e-3)

--- a/changelog/367.breaking.rst
+++ b/changelog/367.breaking.rst
@@ -1,0 +1,1 @@
+Moved ``aiapy.psf.psf.filter_mesh_parameters`` to `aiapy.psf.filter_mesh_parameters`.

--- a/docs/preparing_data.rst
+++ b/docs/preparing_data.rst
@@ -29,7 +29,7 @@ If you want to do any additional data processing steps (e.g., PSF deconvolution)
    * Level 1.5, in its typical usage, only includes steps 1 and 4.
      Unless stated otherwise, any science publication mentioning level 1.5 AIA data does not include steps 2, 3, 5 and 6.
    * The PSF functions are defined on the level 1 pixel grid so PSF deconvolution **MUST** be done on the level 1 data products (i.e., before image registration).
-     This is described in the PSF gallery example :ref:`sphx_glr_generated_gallery_skip_psf_deconvolution.py`.
+     This is described in the PSF gallery example :ref:`sphx_glr_generated_gallery_psf_deconvolution.py`.
    * The pointing update should be done prior to image registration as the updated keywords, namely ``CRPIX1`` and ``CRPIX2``, are used in the image registration step.
    * The exposure time normalization and degradation correction (`aiapy.calibrate.correct_degradation`) operations are just scalar multiplication and are thus linear such that their ordering is inconsequential.
    * Exposure time normalization can be performed by simply dividing a map by the exposure time property, ``my_map / my_map.exposure_time``.

--- a/examples/psf_deconvolution.py
+++ b/examples/psf_deconvolution.py
@@ -35,7 +35,7 @@ import aiapy.psf
 
 aia_map = sunpy.map.Map(sample_data.AIA_171_IMAGE)
 
-fig = plt.figure()
+fig = plt.figure(figsize=(8, 8))
 ax = fig.add_subplot(111, projection=aia_map)
 aia_map.plot(
     axes=ax,
@@ -60,16 +60,17 @@ psf = aiapy.psf.calculate_psf(aia_map.wavelength)
 
 fov = 500
 lc_x, lc_y = psf.shape[0] // 2 - fov // 2, psf.shape[1] // 2 - fov // 2
-fig = plt.figure()
+fig = plt.figure(figsize=(8, 8))
 ax = fig.add_subplot(111)
 ax.imshow(
     psf[lc_x : lc_x + fov, lc_y : lc_y + fov],
     norm=ImageNormalize(vmin=1e-8, vmax=1e-3, stretch=LogStretch()),
     origin="lower",
 )
-ax.set_title("PSF")
+ax.set_title(f"AIA {aia_map.wavelength.value:.0f} Å PSF")
 ax.set_xlabel("Pixels")
 ax.set_ylabel("Pixels")
+plt.colorbar(ax.images[0], ax=ax, label="Normalized Intensity")
 
 ###############################################################################
 # Now that we've downloaded our image and computed the PSF, we can deconvolve
@@ -87,7 +88,7 @@ aia_map_deconvolved = aiapy.psf.deconvolve(aia_map, psf=psf)
 ###############################################################################
 # Let's compare the convolved and deconvolved images.
 
-fig = plt.figure()
+fig = plt.figure(figsize=(12, 8))
 ax = fig.add_subplot(121, projection=aia_map)
 norm = ImageNormalize(vmin=0, vmax=1.5e4, stretch=AsinhStretch(0.01))
 aia_map.plot(axes=ax, norm=norm)
@@ -117,7 +118,7 @@ aia_map_deconvolved_sub = aia_map_deconvolved.submap(
     top_right=SkyCoord(*right_corner, frame=aia_map_deconvolved.coordinate_frame),
 )
 
-fig = plt.figure()
+fig = plt.figure(figsize=(12, 8))
 
 ax = fig.add_subplot(121, projection=aia_map_sub)
 aia_map_sub.plot(axes=ax, norm=norm)
@@ -129,5 +130,6 @@ ax.set_title("Deconvolved")
 ax.coords[0].set_axislabel(" ")
 ax.coords[1].set_axislabel(" ")
 ax.coords[1].set_ticklabel_visible(visible=False)
+fig.tight_layout()
 
 plt.show()


### PR DESCRIPTION
## Summary by Sourcery

Refactor the PSF submodule by moving mesh parameter utilities into a separate file, clean up public API and deprecation metadata, enhance the PSF example plotting script, and standardize test assertion methods across the codebase with updated tolerances.

Enhancements:
- Refactor filter_mesh_parameters into aiapy.psf.utils and streamline psf module exports
- Update deprecation decorator to use version 0.11.0 for psf
- Enhance example script with explicit figure sizing, dynamic titles, colorbars, and tight layout

Documentation:
- Add a breaking change entry for this update in the changelog

Tests:
- Standardize assertions to use np.testing.assert_allclose across tests with appropriate tolerances
- Introduce new test_utils module housing tests for filter_mesh_parameters