### PR TITLE
Updates from the package template

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/sunpy/package-template",
-  "commit": "1d401549c3ffe672d03c0f4635586f57e52b64ef",
+  "commit": "156c3172b548a3dc477cb47be8ccfae48c1f8be1",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -32,7 +32,7 @@
         ".github/workflows/sub_package_update.yml"
       ],
       "_template": "https://github.com/sunpy/package-template",
-      "_commit": "1d401549c3ffe672d03c0f4635586f57e52b64ef"
+      "_commit": "156c3172b548a3dc477cb47be8ccfae48c1f8be1"
     }
   },
   "directory": null

--- a/.github/workflows/sub_package_update.yml
+++ b/.github/workflows/sub_package_update.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
This is an autogenerated PR, which will applies the latest changes from the [SunPy Package Template](https://github.com/sunpy/package-template).
If this pull request has been opened as a draft there are conflicts which need fixing.

**To run the CI on this pull request you will need to close it and reopen it.**

## Summary by Sourcery

Apply automated updates from the SunPy package template, including upgrading the setup-python action to v6 in the CI workflow and updating cruft configuration.

Enhancements:
- Bump actions/setup-python to v6 in the sub_package_update CI workflow

CI:
- Update the sub_package_update GitHub Actions workflow with the latest template changes

Chores:
- Refresh cruft configuration from the package template