### PR TITLE
Do not explicitly require passing parameter tables into functions

### DIFF
--- a/aiapy/calibrate/meta.py
+++ b/aiapy/calibrate/meta.py
@@ -9,12 +9,13 @@ import numpy as np
 
 import astropy.units as u
 
+from aiapy.calibrate.utils import get_pointing_table
 from aiapy.utils.exceptions import AIApyUserWarning
 
 __all__ = ["update_pointing"]
 
 
-def update_pointing(smap, *, pointing_table):
+def update_pointing(smap, *, pointing_table=None):
     """
     Update the pointing information in the input map header.
 
@@ -63,6 +64,8 @@ def update_pointing(smap, *, pointing_table):
             "likely incorrect."
         )
         warnings.warn(msg, AIApyUserWarning, stacklevel=3)
+    if pointing_table is None:
+        pointing_table = get_pointing_table()
     # Find row in which T_START <= T_OBS < T_STOP
     # The following notes are from a private communication with J. Serafin (LMSAL)
     # and are preserved here to explain the reasoning for selecting the particular

--- a/aiapy/calibrate/prep.py
+++ b/aiapy/calibrate/prep.py
@@ -13,7 +13,7 @@ from sunpy.map.sources.sdo import AIAMap, HMIMap
 from sunpy.util.decorators import add_common_docstring
 
 from aiapy.calibrate.transform import _rotation_function_names
-from aiapy.calibrate.utils import _select_epoch_from_correction_table
+from aiapy.calibrate.utils import _select_epoch_from_correction_table, get_correction_table
 from aiapy.utils import AIApyUserWarning
 from aiapy.utils.decorators import validate_channel
 
@@ -115,7 +115,7 @@ def register(smap, *, missing=None, order=3, method="scipy"):
     return newmap
 
 
-def correct_degradation(smap, *, correction_table):
+def correct_degradation(smap, *, correction_table=None):
     """
     Apply time-dependent degradation correction to an AIA map.
 
@@ -155,7 +155,7 @@ def degradation(
     channel: u.angstrom,
     obstime,
     *,
-    correction_table,
+    correction_table=None,
 ) -> u.dimensionless_unscaled:
     r"""
     Correction to account for time-dependent degradation of the instrument.
@@ -205,6 +205,8 @@ def degradation(
     aiapy.response.Channel.wavelength_response
     aiapy.response.Channel.eve_correction
     """
+    if correction_table is None:
+        correction_table = get_correction_table()
     if obstime.shape == ():
         obstime = obstime.reshape((1,))
     ratio = np.zeros(obstime.shape)

--- a/aiapy/calibrate/uncertainty.py
+++ b/aiapy/calibrate/uncertainty.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import astropy.units as u
 
+from aiapy.calibrate.utils import get_error_table
 from aiapy.utils import telescope_number
 from aiapy.utils.decorators import validate_channel
 
@@ -22,7 +23,7 @@ def estimate_error(
     include_preflight=False,
     include_eve=False,
     include_chianti=False,
-    error_table,
+    error_table=None,
     **kwargs,
 ) -> u.DN / u.pix:
     """
@@ -67,6 +68,8 @@ def estimate_error(
     aiapy.calibrate.utils.get_error_table
     """
     counts = np.atleast_1d(counts)
+    if error_table is None:
+        error_table = get_error_table()
     error_table = error_table[error_table["WAVELNTH"] == channel]
     # Shot noise
     # NOTE: pixel and photon are "unitless" so we multiply/divide by these

--- a/aiapy/calibrate/utils.py
+++ b/aiapy/calibrate/utils.py
@@ -198,7 +198,7 @@ def _get_time(time_range: Time | TimeRange | list | tuple):
     return start, end
 
 
-def get_pointing_table(source="lmsal", time_range=None):
+def get_pointing_table(source="jsoc", time_range=None):
     """
     Retrieve 3-hourly master pointing table from the given source.
 

--- a/aiapy/calibrate/utils.py
+++ b/aiapy/calibrate/utils.py
@@ -62,7 +62,7 @@ def _fetch_error_table_latest():
     return manager.get("error_table_latest")
 
 
-def get_correction_table(source):
+def get_correction_table(source="SSW"):
     """
     Return table of degradation correction factors.
 
@@ -198,7 +198,7 @@ def _get_time(time_range: Time | TimeRange | list | tuple):
     return start, end
 
 
-def get_pointing_table(source, *, time_range=None):
+def get_pointing_table(source="lmsal", time_range=None):
     """
     Retrieve 3-hourly master pointing table from the given source.
 

--- a/aiapy/response/channel.py
+++ b/aiapy/response/channel.py
@@ -15,7 +15,7 @@ from sunpy.util.metadata import MetaDict
 
 from aiapy import _SSW_MIRRORS
 from aiapy.calibrate import degradation
-from aiapy.calibrate.utils import _select_epoch_from_correction_table
+from aiapy.calibrate.utils import _select_epoch_from_correction_table, get_correction_table
 from aiapy.data._manager import manager
 from aiapy.utils import telescope_number
 from aiapy.utils.decorators import validate_channel
@@ -282,7 +282,7 @@ class Channel:
         return u.Quantity(np.zeros(self.wavelength.shape), u.cm**2)
 
     @u.quantity_input
-    def eve_correction(self, obstime, correction_table) -> u.dimensionless_unscaled:
+    def eve_correction(self, obstime, correction_table=None) -> u.dimensionless_unscaled:
         r"""
         Correct effective area to give good agreement with full-disk EVE data.
 
@@ -320,6 +320,8 @@ class Channel:
         --------
         aiapy.calibrate.utils.get_correction_table
         """
+        if correction_table is None:
+            correction_table = get_correction_table()
         table = _select_epoch_from_correction_table(
             self.channel,
             obstime,
@@ -363,7 +365,7 @@ class Channel:
         obstime=None,
         include_eve_correction=False,
         include_crosstalk=True,
-        correction_table,
+        correction_table=None,
     ) -> u.DN / u.ph * u.cm**2:
         r"""
         The wavelength response function is the product of the gain and the

--- a/changelog/369.breaking.1.rst
+++ b/changelog/369.breaking.1.rst
@@ -1,0 +1,3 @@
+Passing a correction table or pointing table explicitly is no longer required for functions that
+use these tables. In cases where a table is not passed explicitly, the a table is created using
+the default source.

--- a/changelog/369.breaking.2.rst
+++ b/changelog/369.breaking.2.rst
@@ -1,0 +1,4 @@
+Make the ``source`` keyword for :func:`~aiapy.calibrate.utils.get_correction_table` and
+:func:`~aiapy.calibrate.utils.get_pointing_table` optional. The default source for
+:func:`~aiapy.calibrate.utils.get_correction_table` "SSW" is and the default source for
+:func:`~aiapy.calibrate.utils.get_pointing_table` is "jsoc".


### PR DESCRIPTION
There are several functions which require tables of parameters from external sources (e.g. updating pointing, calculating degradation). Originally, many of these were downloaded from the JSOC. During the outage earlier this year, these functions were modified to provide alternate sources and the higher-level functions then were made to require passing these tables explicitly to avoid unexpected failures.

This PR makes those tables optional again and allows the functions that fetch those tables to rely on default sources that are not the JSOC. In all cases, these default sources cache their downloaded data so multiple network calls are avoided.

- [x] changelog
- [x] check test coverage
- [x] docs update?

## Summary by Sourcery

Allow calibration functions to fetch their required parameter tables internally by making table arguments optional and defaulting to cached sources, removing the need to pass tables explicitly.

Enhancements:
- Make correction_table optional in degradation and EVE correction routines and fetch defaults via get_correction_table
- Allow update_pointing to default to get_pointing_table when no pointing_table is provided
- Default estimate_error’s error_table argument to auto-fetch via get_error_table
- Set default sources for get_correction_table ("SSW") and get_pointing_table ("lmsal") in utils to support implicit fetching

## Summary by Sourcery

Restore implicit fetching of calibration parameter tables by making table arguments optional and defaulting to cached sources

Enhancements:
- Allow correct_degradation, degradation, eve_correction, and wavelength_response to auto-fetch correction tables when none are provided
- Allow update_pointing to auto-fetch pointing tables when none are supplied
- Allow estimate_error to auto-fetch error tables when none are passed
- Set default sources for get_correction_table and get_pointing_table to "SSW" and "jsoc" respectively with built-in caching

Documentation:
- Add breaking change entries to the changelog for implicit table sourcing