### PR TITLE
Updates from the package template

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/sunpy/package-template",
-  "commit": "156c3172b548a3dc477cb47be8ccfae48c1f8be1",
+  "commit": "7958151d0246956f1e95889e8e3fa5abc4a3a129",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -32,7 +32,7 @@
         ".github/workflows/sub_package_update.yml"
       ],
       "_template": "https://github.com/sunpy/package-template",
-      "_commit": "156c3172b548a3dc477cb47be8ccfae48c1f8be1"
+      "_commit": "7958151d0246956f1e95889e8e3fa5abc4a3a129"
     }
   },
   "directory": null

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         args: ["--in-place", "--pre-summary-newline", "--make-summary-multi"]
     # This should be before any formatting hooks like isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.12.11"
+    rev: "v0.13.2"
     hooks:
       - id: ruff
         args: ["--fix", "--unsafe-fixes"]


### PR DESCRIPTION
This is an autogenerated PR, which will applies the latest changes from the [SunPy Package Template](https://github.com/sunpy/package-template).
If this pull request has been opened as a draft there are conflicts which need fixing.

**To run the CI on this pull request you will need to close it and reopen it.**

## Summary by Sourcery

Apply the latest SunPy package template updates, including updating the pre-commit ruff version and regenerating the cruft metadata.

Enhancements:
- Bump ruff pre-commit hook to v0.13.2 for updated linting

Chores:
- Refresh cruft configuration to match the latest package template