### PR TITLE
Include package data files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,9 @@ Changelog = "https://aiapy.readthedocs.io/en/stable/changelog.html"
 zip-safe = false
 include-package-data = true
 
+[tool.setuptools.package-data]
+aiapy = ["*.rst"]
+
 [tool.setuptools.packages.find]
 include = ["aiapy*"]
 exclude = ["aiapy._dev*"]


### PR DESCRIPTION
While switching from PyPI archive to Git source during Guix Astro Update 2026/04 I've noticed that CITATION.rst was not included in `pyproject.toml` - this change fixes that issue.

See the setuptools specs:
https://setuptools.pypa.io/en/latest/userguide/datafiles.html