### PR TITLE
cruft update

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,8 @@ omit =
   aiapy/*setup_package*
   aiapy/extern/*
   aiapy/version*
+  aiapy/_dev/*
+  */aiapy/_dev/*
   */aiapy/conftest.py
   */aiapy/*setup_package*
   */aiapy/extern/*

--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/sunpy/package-template",
-  "commit": "4c4701e4fe00e17a18e36e189b2928cd69983264",
+  "commit": "cc15a3492324a0415ea444c5f52b1913323ad3ba",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -33,7 +33,7 @@
         ".github/workflows/sub_package_update.yml"
       ],
       "_template": "https://github.com/sunpy/package-template",
-      "_commit": "4c4701e4fe00e17a18e36e189b2928cd69983264"
+      "_commit": "cc15a3492324a0415ea444c5f52b1913323ad3ba"
     }
   },
   "directory": null

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,4 +150,4 @@ jobs:
       - run: ls -lha dist/
 
       - name: Run upload
-        uses: pypa/gh-action-pypi-publish@v1.14.0  # zizmor: ignore[unpinned-uses]
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 exclude: "(.*/)?CITATION.rst$|.*(.fits|.fts|.fit|.header|.txt|tca.*|extern.*|aiapy/extern)$"
 repos:
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.23.1
+    rev: v1.25.2
     hooks:
       - id: zizmor
     # This should be before any formatting hooks like isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.9"
+    rev: "v0.15.13"
     hooks:
       - id: ruff
         args: ["--fix", "--unsafe-fixes"]
@@ -17,7 +17,7 @@ repos:
         types: [python]
         exclude: *exclude_dirs
   - repo: https://github.com/PyCQA/isort
-    rev: 8.0.1
+    rev: 9.0.0a3
     hooks:
       - id: isort
         types: [python]
@@ -48,7 +48,7 @@ repos:
       - id: mixed-line-ending
   # See https://github.com/python-trio/trio/pull/3255
   -   repo: https://github.com/adhtruong/mirrors-typos
-      rev: v1.45.0
+      rev: v1.46.2
       hooks:
       - id: typos
         exclude: *exclude_dirs


### PR DESCRIPTION
## Summary by Sourcery

Update project tooling configuration and CI publishing action to align with latest cruft template.

Build:
- Bump pre-commit hooks for zizmor, ruff, isort, and typos to newer versions.

CI:
- Pin pypa/gh-action-pypi-publish to a specific commit and configure Dependabot to manage and group GitHub Actions updates.