### PR TITLE
feature: validate_channel allows nm

### DIFF
--- a/aiapy/utils/__init__.py
+++ b/aiapy/utils/__init__.py
@@ -2,4 +2,7 @@
 Subpackage with miscellaneous utility functions.
 """
 
+from .decorators import *
+from .exceptions import *
+from .net import *
 from .utils import *

--- a/aiapy/utils/__init__.py
+++ b/aiapy/utils/__init__.py
@@ -2,7 +2,4 @@
 Subpackage with miscellaneous utility functions.
 """
 
-from .decorators import *
-from .exceptions import *
-from .net import *
 from .utils import *

--- a/aiapy/utils/decorators.py
+++ b/aiapy/utils/decorators.py
@@ -45,7 +45,11 @@ def validate_channel(argument, *, valid_channels="all"):
         def inner(*args, **kwargs):
             all_args = sig.bind(*args, **kwargs)
             channel = all_args.arguments[argument]
-            if channel not in valid_channels:
+            try:
+                is_valid = any(u.isclose(channel, c) for c in valid_channels)
+            except (u.UnitsError, TypeError, ValueError):
+                is_valid = False
+            if not is_valid:
                 msg = f'channel "{channel}" not in list of valid channels: {valid_channels}.'
                 raise ValueError(msg)
             return function(*args, **kwargs)

--- a/aiapy/utils/decorators.py
+++ b/aiapy/utils/decorators.py
@@ -46,8 +46,8 @@ def validate_channel(argument, *, valid_channels="all"):
             all_args = sig.bind(*args, **kwargs)
             channel = all_args.arguments[argument]
             try:
-                is_valid = any(u.isclose(channel, c) for c in valid_channels)
-            except (u.UnitsError, TypeError, ValueError):
+                is_valid = isinstance(channel, u.Quantity) and any(u.isclose(channel, c) for c in valid_channels)
+            except u.UnitsError:
                 is_valid = False
             if not is_valid:
                 msg = f'channel "{channel}" not in list of valid channels: {valid_channels}.'

--- a/aiapy/utils/tests/test_decorators.py
+++ b/aiapy/utils/tests/test_decorators.py
@@ -1,0 +1,44 @@
+import pytest
+
+import astropy.units as u
+
+from aiapy.utils.decorators import _all_channels, validate_channel
+
+
+@validate_channel("channel")
+def identity(channel):
+    return channel
+
+
+@pytest.mark.parametrize("channel", _all_channels)
+def test_valid_channel(channel) -> None:
+    assert identity(channel) == channel
+
+
+@pytest.mark.parametrize("channel", [c.to(u.nm) for c in _all_channels])
+def test_valid_channel_equivalent_unit(channel) -> None:
+    assert identity(channel) == channel
+
+
+@pytest.mark.parametrize("channel", [1 * u.angstrom, 94, "94", None])
+def test_invalid_channel_raises_error(channel) -> None:
+    with pytest.raises(ValueError, match="not in list of valid channels"):
+        identity(channel)
+
+
+def test_custom_valid_channels() -> None:
+    @validate_channel("channel", valid_channels=[94 * u.angstrom])
+    def f(channel):
+        return channel
+
+    assert f(94 * u.angstrom) == 94 * u.angstrom
+    with pytest.raises(ValueError, match="not in list of valid channels"):
+        f(171 * u.angstrom)
+
+
+def test_missing_argument_raises_error() -> None:
+    with pytest.raises(ValueError, match="Did not find channel in function signature"):
+
+        @validate_channel("channel")
+        def f(not_channel):
+            return not_channel

--- a/aiapy/utils/tests/test_decorators.py
+++ b/aiapy/utils/tests/test_decorators.py
@@ -20,10 +20,22 @@ def test_valid_channel_equivalent_unit(channel) -> None:
     assert identity(channel) == channel
 
 
-@pytest.mark.parametrize("channel", [1 * u.angstrom, 94, "94", None])
+@pytest.mark.parametrize("channel", [1 * u.angstrom, 195 * u.angstrom, 94 * u.s, 94, "94", None])
 def test_invalid_channel_raises_error(channel) -> None:
     with pytest.raises(ValueError, match="not in list of valid channels"):
         identity(channel)
+
+
+def test_channel_as_keyword_or_later_positional_argument() -> None:
+    @validate_channel("channel")
+    def f(_other, channel, _extra=None):
+        return channel
+
+    assert f(1, 94 * u.angstrom) == 94 * u.angstrom
+    assert f(1, channel=94 * u.angstrom) == 94 * u.angstrom
+    assert f(_extra=2, channel=94 * u.angstrom, _other=1) == 94 * u.angstrom
+    with pytest.raises(ValueError, match="not in list of valid channels"):
+        f(1, channel=195 * u.angstrom)
 
 
 def test_custom_valid_channels() -> None:

--- a/aiapy/utils/tests/test_utils.py
+++ b/aiapy/utils/tests/test_utils.py
@@ -2,7 +2,8 @@ import pytest
 
 from astropy.tests.helper import assert_quantity_allclose
 
-from aiapy.utils.utils import _QUALITY_FLAG_MESSAGES, check_quality_flag, sdo_location
+from aiapy.utils import check_quality_flag, sdo_location
+from aiapy.utils.utils import _QUALITY_FLAG_MESSAGES
 
 
 @pytest.mark.remote_data

--- a/aiapy/utils/tests/test_utils.py
+++ b/aiapy/utils/tests/test_utils.py
@@ -2,14 +2,13 @@ import pytest
 
 from astropy.tests.helper import assert_quantity_allclose
 
-import aiapy.utils
-from aiapy.utils.utils import _QUALITY_FLAG_MESSAGES
+from aiapy.utils.utils import _QUALITY_FLAG_MESSAGES, check_quality_flag, sdo_location
 
 
 @pytest.mark.remote_data
 def test_sdo_location(aia_171_map) -> None:
     # Confirm that the queried location matches AIAMap's interpretation of the FITS file
-    result = aiapy.utils.sdo_location(aia_171_map.date)
+    result = sdo_location(aia_171_map.date)
     aia_171_map.observer_coordinate.transform_to(result)
     assert_quantity_allclose(result.cartesian.xyz, result.cartesian.xyz)
 
@@ -18,16 +17,16 @@ def test_sdo_location(aia_171_map) -> None:
 def test_sdo_location_raises_error() -> None:
     # Confirm that an error is raised for a time without records
     with pytest.raises(RuntimeError, match="No data found for this query"):
-        aiapy.utils.sdo_location("2001-01-01")
+        sdo_location("2001-01-01")
 
 
 @pytest.mark.parametrize(
     "bits",
     [
-        [],  # nominal
-        [16],  # single message
-        [12, 13, 14, 17, 21],  # multiple messages
-        [4, 5],  # empty bits
+        [],  # Nominal
+        [16],  # Single message
+        [12, 13, 14, 17, 21],  # Multiple messages
+        [4, 5],  # Empty bits
     ],
 )
 def test_check_quality_flag(bits):
@@ -37,4 +36,4 @@ def test_check_quality_flag(bits):
     messages = ["nominal"]
     if bits:
         messages = [_QUALITY_FLAG_MESSAGES.get(b, "(empty)") for b in bits]
-    assert messages == aiapy.utils.check_quality_flag(quality)
+    assert messages == check_quality_flag(quality)

--- a/changelog/410.bugfix.rst
+++ b/changelog/410.bugfix.rst
@@ -1,0 +1,1 @@
+Functions that validate their ``channel`` argument (e.g., `~aiapy.calibrate.correct_degradation`, `aiapy.psf.psf`) now accept any unit equivalent to Angstrom (e.g., nanometers).


### PR DESCRIPTION
## Summary by Sourcery

Ensure channel validation correctly handles equivalent units and expand test coverage for utility decorators and quality checks.

Bug Fixes:
- Allow validate_channel to accept channels expressed in equivalent units while safely rejecting invalid inputs.

Documentation:
- Add a changelog entry documenting the channel validation bug fix.

Tests:
- Add comprehensive tests for validate_channel, including equivalent-unit handling, invalid inputs, custom channel lists, and missing-argument behavior.
- Refine existing utils tests to use direct imports for sdo_location and check_quality_flag.