### PR TITLE
chore: cruft update

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/sunpy/package-template",
-  "commit": "a31905a50a3889e42d9ca50065a4a4276ea62511",
+  "commit": "4ba8b7c6a6bf4f51f7154978ae8d2f3710ef89e5",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -22,6 +22,7 @@
       "enable_dynamic_dev_versions": "y",
       "include_example_code": "y",
       "include_cruft_update_github_workflow": "y",
+      "use_pat_in_cruft_update_workflow": "y",
       "use_extended_ruff_linting": "y",
       "matrix_room_id": "",
       "extra_ci_jobs": "",
@@ -30,11 +31,10 @@
       "_install_requires": "",
       "_copy_without_render": [
         "docs/_templates",
-        "docs/_static",
-        ".github/workflows/sub_package_update.yml"
+        "docs/_static"
       ],
       "_template": "https://github.com/sunpy/package-template",
-      "_commit": "a31905a50a3889e42d9ca50065a4a4276ea62511"
+      "_commit": "4ba8b7c6a6bf4f51f7154978ae8d2f3710ef89e5"
     }
   },
   "directory": null

--- a/.github/workflows/sub_package_update.yml
+++ b/.github/workflows/sub_package_update.yml
@@ -5,6 +5,12 @@ name: Automatic Update from package template
 on:
   # Allow manual runs through the web UI
   workflow_dispatch:
+    inputs:
+      extra_context:
+        description: 'JSON of cookiecutter variables to update (passed to cruft --variables-to-update), e.g. {"project": "new-name"}'
+        required: false
+        default: ''
+        type: string
   schedule:
     #        ┌───────── minute (0 - 59)
     #        │ ┌───────── hour (0 - 23)
@@ -19,8 +25,10 @@ jobs:
   update:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       pull-requests: write
+    environment:
+      name: sub_package_update
+      deployment: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -51,11 +59,18 @@ jobs:
       - name: Run update if available
         id: cruft_update
         if: steps.check.outputs.has_changes == '1'
+        env:
+          EXTRA_CONTEXT: ${{ inputs.extra_context }}
         run: |
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git config --global user.name "${GITHUB_ACTOR}"
 
-          cruft_output=$(cruft update --skip-apply-ask --refresh-private-variables)
+          EXTRA_ARGS=()
+          if [ -n "$EXTRA_CONTEXT" ]; then
+            EXTRA_ARGS=(--variables-to-update "$EXTRA_CONTEXT")
+          fi
+
+          cruft_output=$(cruft update --skip-apply-ask --refresh-private-variables "${EXTRA_ARGS[@]}")
           echo $cruft_output
           git restore --staged .
 
@@ -82,6 +97,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          branch-token: ${{ secrets.WORKFLOWS_UPDATE_PAT }}
           add-paths: "."
           commit-message: "Automatic package template update"
           branch: "cruft/update"


### PR DESCRIPTION
## Summary by Sourcery

Allow customizing cruft sub-package updates via workflow inputs and adjust GitHub workflow permissions and credentials for automated update PRs.

Enhancements:
- Add workflow_dispatch input for passing extra cookiecutter context into cruft update runs.
- Configure sub_package_update job environment and deployment settings.
- Update cruft update step to accept optional variables-to-update arguments from workflow inputs.
- Use a dedicated branch token secret for create-pull-request when opening automated update branches.

CI:
- Adjust GitHub Actions permissions and environment configuration for the sub_package_update workflow.